### PR TITLE
CircleCIのMysql8サーバー接続問題を解消 (unknown host 'db')

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
         command: [--default-authentication-plugin=mysql_native_password]
         environment:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
-          MYSQL_ROOT_PASSWORD: ""
+          MYSQL_ROOT_PASSWORD: "password"
           MYSQL_DATABASE: test_db
           MYSQL_HOST: 127.0.0.1
           MYSQL_ROOT_HOST: "%"

--- a/config/database.yml
+++ b/config/database.yml
@@ -15,12 +15,12 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password: password
-  host: db
+  host: "127.0.0.1"
 
 development:
   <<: *default
   database: DoingLog_development
-  host: "127.0.0.1"
+  host: db
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,6 +20,7 @@ default: &default
 development:
   <<: *default
   database: DoingLog_development
+  host: "127.0.0.1"
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".

--- a/config/database.yml
+++ b/config/database.yml
@@ -15,11 +15,12 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password: password
-  host: db
+  host: "127.0.0.1"
 
 development:
   <<: *default
   database: DoingLog_development
+  host: db
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".

--- a/config/database.yml
+++ b/config/database.yml
@@ -15,12 +15,11 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password: password
-  host: "127.0.0.1"
+  host: db
 
 development:
   <<: *default
   database: DoingLog_development
-  host: db
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".


### PR DESCRIPTION
## 生じていた問題
CircleCIにて、以前より下記のエラーを吐き続けていた。
~~~
Unknown MySQL server host 'db' (-2)
Couldn't create 'DoingLog_test' database. Please check your configuration.
rake aborted!
Mysql2::Error::ConnectionError: Unknown MySQL server host 'db' (-2)
~~~

## 対処

./circleci/config.ymlの``MYSQL_ROOT_PASSWORD``が"(空)"で、database.yml
~~~yml:database.yml
password: password
~~~
と矛盾していたことがおそらく原因。
./circleci/config.ymlにおいて
~~~yml:./circleci/config.yml
MYSQL_ROOT_PASSWORD: "password"
~~~
と変更したところ、問題が解消した。