### PR TITLE
Solve specs for Doings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,9 @@ jobs:
           keys:
             - v1-dependencies-{{ checksum "Gemfile.lock" }}
             - v1-dependencies-
+      - run:
+          name: Yarn のインストール
+          command: yarn install --cache-folder ~/.cache/yarn
       - run: gem install bundler -v 2.0.1
       - run: bundle install --jobs=4 --retry=3 --path vendor/bundle
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,15 +26,23 @@ jobs:
           keys:
             - v1-dependencies-{{ checksum "Gemfile.lock" }}
             - v1-dependencies-
-      - run:
-          name: Yarn のインストール
-          command: yarn install --cache-folder ~/.cache/yarn
       - run: gem install bundler -v 2.0.1
       - run: bundle install --jobs=4 --retry=3 --path vendor/bundle
       - save_cache:
           paths:
             - ./vendor/bundle
           key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+      - restore_cache:
+          keys:
+            - rails-demo-yarn-{{ checksum "yarn.lock" }}
+            - rails-demo-yarn-
+      - run:
+          name: Yarn のインストール
+          command: yarn install --cache-folder ~/.cache/yarn
+      - save_cache:
+          key: rails-demo-yarn-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/.cache/yarn
       - run: 
           name: Wait Docker container
           command: dockerize -wait tcp://127.0.0.1:3306 -timeout 2m

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,6 @@
 @import "bootstrap";
 @import "./users";
+@import "./doings";
 @import "./tags";
 @import "./header";
 @import "./sidebar";

--- a/app/assets/stylesheets/doing_logs.scss
+++ b/app/assets/stylesheets/doing_logs.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the Doings controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/assets/stylesheets/doings.scss
+++ b/app/assets/stylesheets/doings.scss
@@ -1,10 +1,10 @@
-.user_cards {
-  .user_card {
+.doing_cards {
+  .doing_card {
     margin: 2px;
     padding: 10px;
     border: 1px solid;
     border-radius: 5px;
-    #user_btn {
+    #doing_btn {
       margin: 1px;
       #edit_btn {
         margin: 1px;

--- a/app/controllers/doings_controller.rb
+++ b/app/controllers/doings_controller.rb
@@ -1,4 +1,7 @@
 class DoingsController < ApplicationController
+  # [devise由来] ログイン済ユーザーにのみアクセスを許可する。
+  before_action :authenticate_user!, except: %i[index show]
+
   def index
     @doings = Doing.all
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   # [devise由来] ログイン済ユーザーにのみアクセスを許可する。
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: %i[index show]
   
   def index
     @users = User.all

--- a/app/models/doing.rb
+++ b/app/models/doing.rb
@@ -3,7 +3,7 @@
 class Doing < ApplicationRecord
   belongs_to :user, counter_cache: :doing_count
 
-  validates :title, presence: true, message: "取り組み事項のタイトルは必須入力項目です"
-  validates :title, length: { maximum: 100, message: "タイトルは%{length}文字以内にしてください" }
-  validates :summary, length: { maximum: 1000, message: "概要は%{length}文字以内にしてください" }
+  validates :title, presence: { message: "取り組み事項のタイトルは必須入力項目です" }
+  validates :title, length: { maximum: 100, message: "タイトルは100文字以内にしてください" }
+  validates :summary, length: { maximum: 1000, message: "概要は1000文字以内にしてください" }
 end

--- a/app/models/doing.rb
+++ b/app/models/doing.rb
@@ -5,5 +5,6 @@ class Doing < ApplicationRecord
 
   validates :title, presence: { message: "取り組み事項のタイトルは必須入力項目です" }
   validates :title, length: { maximum: 100, message: "タイトルは100文字以内にしてください" }
+  validates :title, uniqueness: { message: "既に使用されているタイトルは登録できません" }
   validates :summary, length: { maximum: 1000, message: "概要は1000文字以内にしてください" }
 end

--- a/app/models/doing.rb
+++ b/app/models/doing.rb
@@ -3,7 +3,7 @@
 class Doing < ApplicationRecord
   belongs_to :user, counter_cache: :doing_count
 
-  validates :title, :body, presence: true
+  validates :title, :summary, presence: true
   validates :title, length: { maximum: 100 }
   validates :summary, length: { maximum: 1000 }
 end

--- a/app/models/doing.rb
+++ b/app/models/doing.rb
@@ -3,7 +3,7 @@
 class Doing < ApplicationRecord
   belongs_to :user, counter_cache: :doing_count
 
-  validates :title, :summary, presence: true
-  validates :title, length: { maximum: 100 }
-  validates :summary, length: { maximum: 1000 }
+  validates :title, presence: { true, message: "取り組み事項のタイトルは必須入力項目です" }
+  validates :title, length: { maximum: 100, message: "タイトルは%{length}文字以内にしてください" }
+  validates :summary, length: { maximum: 1000, message: "概要は%{length}文字以内にしてください" }
 end

--- a/app/models/doing.rb
+++ b/app/models/doing.rb
@@ -3,7 +3,7 @@
 class Doing < ApplicationRecord
   belongs_to :user, counter_cache: :doing_count
 
-  validates :title, presence: { true, message: "取り組み事項のタイトルは必須入力項目です" }
+  validates :title, presence: true, message: "取り組み事項のタイトルは必須入力項目です"
   validates :title, length: { maximum: 100, message: "タイトルは%{length}文字以内にしてください" }
   validates :summary, length: { maximum: 1000, message: "概要は%{length}文字以内にしてください" }
 end

--- a/app/views/doings/_doing_card.html.erb
+++ b/app/views/doings/_doing_card.html.erb
@@ -1,25 +1,19 @@
-<div class="card" id="doing-card">
-  <div class="card-header p-1 border-secondary">
+<div class='doing_card'>
+  <div class="">
     <%= link_to doing.user do %>
-    <div class="d-flex p-0">
-      <div class="d-flex flex-column align-self-center">
-        <div class="mr-1 font-weight-bold text-left">
-          <%= doing.user.username %>
+    <div class="">
+      <div class="">
+        <div class="">
+          @<%= doing.user.username %>
         </div>
         <div class="text-truncate" id="date"><%= doing.created_at.strftime("%m月%d日 %H:%M") %></div>
+        <div class="d-flex align-self-center">
+          <%= render 'doings/doing_edit_or_delete_btn', doing: doing %>
+        </div>
       </div>
     </div>
     <% end %>
   </div>
-  <div class="card-header border-secondary rounded-0 p-1 pl-2" id="title">
-    <%= doing.title %>
-  </div>
-  <div class="card-header p-1 d-flex justify-content-between">
-    <div class="d-flex align-self-center">
-      <%= render 'doings/doing_edit_or_delete_btn', doing: doing %>
-    </div>
-  </div>
-  <div class="card-summery">
-    <%= doing.content %>
-  </div>
+  <div><%= doing.title %></div>
+  <div> <%= doing.summary %></div>
 </div>

--- a/app/views/doings/_doing_card.html.erb
+++ b/app/views/doings/_doing_card.html.erb
@@ -14,6 +14,8 @@
     </div>
     <% end %>
   </div>
-  <div><%= doing.title %></div>
+  <%= link_to doing do %>
+    <div><%= doing.title %></div>
+  <% end %>
   <div> <%= doing.summary %></div>
 </div>

--- a/app/views/doings/_doing_edit_or_delete_btn.html.erb
+++ b/app/views/doings/_doing_edit_or_delete_btn.html.erb
@@ -2,8 +2,8 @@
   <div class="d-flex justify-content-between">
     <div>
       <% if current_user.id == doing.user.id %>
-        <%= link_to "削除", doing, method: :delete, data: { confirm: '本当に削除しますか？' }, class: 'float-left mr-3 btn-sm btn-light', id: 'delete-btn' %>
-        <%= link_to "編集", [:edit, doing], class: 'float-left mr-3 btn-sm btn-light' ,id: 'edit-btn' %>
+        <%= link_to "削除", doing, method: :delete, data: { confirm: '本当に削除しますか？' }, class: '', id: 'delete-btn' %>
+        <%= link_to "編集", [:edit, doing], class: '' ,id: 'edit-btn' %>
       <% end %>
     </div>
   </div>

--- a/app/views/doings/_new_or_edit_template.html.erb
+++ b/app/views/doings/_new_or_edit_template.html.erb
@@ -20,6 +20,10 @@
     <%= f.text_area :summary, autofocus: true, autocomplete: "summary" %>
   </div>
   <div class="actions">
-    <%= f.submit "投稿する" %>
+    <% if current_page?(new_doing_path) %>
+      <%= f.submit '投稿する'%>
+    <% else %>
+      <%= f.submit '編集を登録する'%>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/doings/_new_or_edit_template.html.erb
+++ b/app/views/doings/_new_or_edit_template.html.erb
@@ -1,0 +1,13 @@
+<%= form_for @doing do |f| %>
+  <div class="field">
+    <%= f.label :title %><br />
+    <%= f.text_field :title, autofocus: true, autocomplete: "title" %>
+  </div>
+  <div class="field">
+    <%= f.label :summary %><br />
+    <%= f.text_area :summary, autofocus: true, autocomplete: "summary" %>
+  </div>
+  <div class="actions">
+    <%= f.submit "投稿する" %>
+  </div>
+<% end %>

--- a/app/views/doings/_new_or_edit_template.html.erb
+++ b/app/views/doings/_new_or_edit_template.html.erb
@@ -1,3 +1,15 @@
+<% if @doing.errors.any? %>
+  <div id="error_explanation">
+    <h2><%= pluralize(@doing.errors.count, "error") %> 投稿に失敗しました:</h2>
+
+    <ul>
+    <% @doing.errors.full_messages.each do |msg| %>
+      <li><%= msg %></li>
+    <% end %>
+    </ul>
+  </div>
+<% end %>
+
 <%= form_for @doing do |f| %>
   <div class="field">
     <%= f.label :title %><br />

--- a/app/views/doings/edit.html.erb
+++ b/app/views/doings/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render 'doings/new_or_edit_template', doing: @doing %>

--- a/app/views/doings/index.html.erb
+++ b/app/views/doings/index.html.erb
@@ -1,1 +1,2 @@
+<H3>Doings</H3>
 <%= render 'doings/doings_cards', doings: @doings %>

--- a/app/views/doings/new.html.erb
+++ b/app/views/doings/new.html.erb
@@ -1,0 +1,1 @@
+<%= render 'doings/new_or_edit_template', doing: @doing %>

--- a/app/views/doings/show.html.erb
+++ b/app/views/doings/show.html.erb
@@ -1,0 +1,1 @@
+<%= render 'doings/doing_card', doing: @doing %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -7,7 +7,7 @@
         <li class="nav-item align-self-center">
           <form class="form-inline">
           <% if user_signed_in? %>
-            <%= link_to '新規記事作成', new_doing_url,
+            <%= link_to '新規Doing', new_doing_url,
                 class: 'btn btn-sm btn-dark btn-block navbar-text p-1' %>
           <% end %>
           </form>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,3 +1,4 @@
+<H3>Users</H3>
 <div class="user_cards">
   <%= render 'users/users_cards', users: @users %>
 </div>

--- a/db/migrate/20191127112443_create_doing_logs.rb
+++ b/db/migrate/20191127112443_create_doing_logs.rb
@@ -3,7 +3,7 @@
 class CreateDoingLogs < ActiveRecord::Migration[6.0]
   def change
     create_table :doing_logs do |t|
-      t.string :title
+      t.string :title, null: false
       t.text :summary
 
       t.timestamps

--- a/db/migrate/20191127112603_create_problems.rb
+++ b/db/migrate/20191127112603_create_problems.rb
@@ -3,7 +3,7 @@
 class CreateProblems < ActiveRecord::Migration[6.0]
   def change
     create_table :problems do |t|
-      t.string :title
+      t.string :title, null: false
       t.text :summary
       t.boolean :solved, null: false, default: false
 

--- a/db/migrate/20191127112819_create_tries.rb
+++ b/db/migrate/20191127112819_create_tries.rb
@@ -3,7 +3,7 @@
 class CreateTries < ActiveRecord::Migration[6.0]
   def change
     create_table :tries do |t|
-      t.string :title
+      t.string :title, null: false
       t.text :body
       t.boolean :effective, null: false, default: false
 

--- a/db/migrate/20200811094400_add_doing_count_to_users.rb
+++ b/db/migrate/20200811094400_add_doing_count_to_users.rb
@@ -1,0 +1,5 @@
+class AddDoingCountToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :doing_count, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_06_051348) do
+ActiveRecord::Schema.define(version: 2020_08_11_094400) do
 
   create_table "doings", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
@@ -53,6 +53,7 @@ ActiveRecord::Schema.define(version: 2020_08_06_051348) do
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "admin_flg", default: false
     t.boolean "guest_flg", default: false
+    t.integer "doing_count", default: 0
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/controllers/doings_controller_spec.rb
+++ b/spec/controllers/doings_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe DoingsController, type: :controller do
     end
 
     context 'ログイン無しの場合の応答' do
-      it 'サインインページへのリダイレクト：/doing/show' do
+      it 'ログインページへのリダイレクト：/doing/show' do
         get :show, params: { id: @doing.id }
         expect(response).to redirect_to '/users/sign_in'
       end
@@ -63,7 +63,7 @@ RSpec.describe DoingsController, type: :controller do
     end
 
     context 'ログイン無しの場合の応答' do
-      it 'サインインページへのリダイレクト：/doing/new' do
+      it 'ログインページへのリダイレクト：/doing/new' do
         get :new
         expect(response).to redirect_to '/users/sign_in'
       end
@@ -123,7 +123,7 @@ RSpec.describe DoingsController, type: :controller do
         @doing = FactoryBot.create(:doing, title: "Other's")
       end
 
-      it 'サインインページへのリダイレクト' do
+      it 'ログインページへのリダイレクト' do
         doing_params = FactoryBot.attributes_for(:doing,
                                                      title: 'New doing title')
         patch :update, params: { id: @doing.id,
@@ -178,7 +178,7 @@ RSpec.describe DoingsController, type: :controller do
         @doing = FactoryBot.create(:doing)
       end
 
-      it 'サインインページへのリダイレクト' do
+      it 'ログインページへのリダイレクト' do
         delete :destroy, params: { id: @doing.id }
         expect(response).to redirect_to '/users/sign_in'
       end
@@ -218,7 +218,7 @@ RSpec.describe DoingsController, type: :controller do
     end
 
     context 'ログイン無しの場合の応答' do
-      it 'サインインページへのリダイレクト' do
+      it 'ログインページへのリダイレクト' do
         doing_params = FactoryBot.attributes_for(:doing)
         expect { post :create, params: { doing: doing_params } }.to redirect_to '/users/sign_in'
       end

--- a/spec/controllers/problems_controller_spec.rb
+++ b/spec/controllers/problems_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe ProblemsController, type: :controller do
     end
 
     context 'ログイン無しの場合の応答' do
-      it 'サインインページへのリダイレクト：/problem/show' do
+      it 'ログインページへのリダイレクト：/problem/show' do
         get :show, params: { id: @problem.id }
         expect(response).to redirect_to '/users/sign_in'
       end
@@ -91,7 +91,7 @@ RSpec.describe ProblemsController, type: :controller do
         @problem = FactoryBot.create(:problem, title: "Other's")
       end
 
-      it 'サインインページへのリダイレクト' do
+      it 'ログインページへのリダイレクト' do
         problem_params = FactoryBot.attributes_for(:problem,
                                                    title: 'New problem title')
         patch :update, params: { id: @problem.id,
@@ -148,7 +148,7 @@ RSpec.describe ProblemsController, type: :controller do
         @problem = FactoryBot.create(:problem)
       end
 
-      it 'サインインページへのリダイレクト' do
+      it 'ログインページへのリダイレクト' do
         problem_params = FactoryBot.attributes_for(:problem,
                                                    title: 'New problem title')
         delete :destroy, params: { id: @problem.id }
@@ -192,7 +192,7 @@ RSpec.describe ProblemsController, type: :controller do
     end
 
     context 'ログイン無しの場合の応答' do
-      it 'サインインページへのリダイレクト' do
+      it 'ログインページへのリダイレクト' do
         problem_params = FactoryBot.attributes_for(:problem)
         expect { post :create, params: { problem: problem_params } }.to redirect_to '/users/sign_in'
       end

--- a/spec/controllers/tries_controller_spec.rb
+++ b/spec/controllers/tries_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe TriesController, type: :controller do
     end
 
     context 'ログイン無しの場合の応答' do
-      it 'サインインページへのリダイレクト：/try/show' do
+      it 'ログインページへのリダイレクト：/try/show' do
         get :show, params: { id: @try.id }
         expect(response).to redirect_to '/users/sign_in'
       end
@@ -91,7 +91,7 @@ RSpec.describe TriesController, type: :controller do
         @try = FactoryBot.create(:try, title: "Other's")
       end
 
-      it 'サインインページへのリダイレクト' do
+      it 'ログインページへのリダイレクト' do
         try_params = FactoryBot.attributes_for(:try,
                                                title: 'New try title')
         patch :update, params: { id: @try.id,
@@ -148,7 +148,7 @@ RSpec.describe TriesController, type: :controller do
         @try = FactoryBot.create(:try)
       end
 
-      it 'サインインページへのリダイレクト' do
+      it 'ログインページへのリダイレクト' do
         try_params = FactoryBot.attributes_for(:try,
                                                title: 'New try title')
         delete :destroy, params: { id: @try.id }
@@ -192,7 +192,7 @@ RSpec.describe TriesController, type: :controller do
     end
 
     context 'ログイン無しの場合の応答' do
-      it 'サインインページへのリダイレクト' do
+      it 'ログインページへのリダイレクト' do
         try_params = FactoryBot.attributes_for(:try)
         expect { post :create, params: { try: try_params } }.to redirect_to '/users/sign_in'
       end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe UsersController, type: :controller do
     end
 
     context 'ログイン無しの場合の応答' do
-      it 'サインインページへのリダイレクト：/user/index' do
+      it 'ログインページへのリダイレクト：/user/index' do
         get :index
         expect(response).to redirect_to '/users/sign_in'
       end
@@ -55,7 +55,7 @@ RSpec.describe UsersController, type: :controller do
     end
 
     context 'ログイン無しの場合の応答' do
-      it 'サインインページへのリダイレクト：/user/show' do
+      it 'ログインページへのリダイレクト：/user/show' do
         get :show, params: { id: @user.id }
         expect(response).to redirect_to '/users/sign_in'
       end

--- a/spec/models/doing_spec.rb
+++ b/spec/models/doing_spec.rb
@@ -11,25 +11,25 @@ RSpec.describe DoingLog, type: :model do
   it '文字制限(上限)：titleを101文字で登録する' do
     doing = FactoryBot.build(:doing, title: Faker::Base.regexify('[/\A[ぁ-んァ-ン一-龥]/]{101}'))
     doing.valid?
-    expect(doing.errors[:title]).to include('タイトルは100文字以内にしてください。')
+    expect(doing.errors[:title]).to include('タイトルは100文字以内にしてください')
   end
 
   it '文字制限(上限)：summaryを1001文字で登録する' do
     doing = FactoryBot.build(:doing, summary: Faker::Base.regexify('[aふぃ5786おさgjgsgあ]{1001}'))
     doing.valid?
-    expect(doing.errors[:summary]).to include('概要は1000文字以内にしてください。')
+    expect(doing.errors[:summary]).to include('概要は1000文字以内にしてください')
   end
 
   it '重複不可：既存タイトル(title)を登録する' do
     FactoryBot.create(:doing, title: "オリジナルアプリ'DoingLog'へのRSpecの導入(TDDを意識した開発の準備)")
     doing = FactoryBot.build(:doing, title: "オリジナルアプリ'DoingLog'へのRSpecの導入(TDDを意識した開発の準備)")
     doing.valid?
-    expect(doing.errors[:title]).to include('既に使用されているタイトルは登録できません。')
+    expect(doing.errors[:title]).to include('既に使用されているタイトルは登録できません')
   end
 
   it '必須入力：titleの未入力' do
     doing = FactoryBot.build(:doing, title: nil)
     doing.valid?
-    expect(doing.errors[:title]).to include('取り組み事項のタイトルは必須入力項目です。')
+    expect(doing.errors[:title]).to include('取り組み事項のタイトルは必須入力項目です')
   end
 end

--- a/spec/support/login_support.rb
+++ b/spec/support/login_support.rb
@@ -2,7 +2,7 @@ module LoginSupport
     def sign_in_as(user)
         visit root_path
         click_link "ログイン"
-        fill_in "ユーザー名", with: user.username
+        # fill_in "ユーザー名", with: user.username
         fill_in "Eメール", with: user.email
         fill_in "パスワード", with: user.password
         click_button "ログイン"

--- a/spec/support/login_support.rb
+++ b/spec/support/login_support.rb
@@ -5,6 +5,7 @@ module LoginSupport
         # fill_in "ユーザー名", with: user.username
         fill_in "Eメール", with: user.email
         fill_in "パスワード", with: user.password
+        click_button "Log in"
     end
 end
 

--- a/spec/support/login_support.rb
+++ b/spec/support/login_support.rb
@@ -1,10 +1,10 @@
 module LoginSupport
     def sign_in_as(user)
         visit root_path
+        click_button "ログイン"
         # fill_in "ユーザー名", with: user.username
         fill_in "Eメール", with: user.email
         fill_in "パスワード", with: user.password
-        click_button "ログイン"
     end
 end
 

--- a/spec/support/login_support.rb
+++ b/spec/support/login_support.rb
@@ -1,7 +1,7 @@
 module LoginSupport
     def sign_in_as(user)
         visit root_path
-        click_button "ログイン"
+        click_link "ログイン"
         # fill_in "ユーザー名", with: user.username
         fill_in "Eメール", with: user.email
         fill_in "パスワード", with: user.password

--- a/spec/support/login_support.rb
+++ b/spec/support/login_support.rb
@@ -1,7 +1,7 @@
 module LoginSupport
     def sign_in_as(user)
         visit root_path
-        click_link "サインイン"
+        click_link "ログイン"
         fill_in "ユーザー名", with: user.username
         fill_in "Eメール", with: user.email
         fill_in "パスワード", with: user.password

--- a/spec/support/login_support.rb
+++ b/spec/support/login_support.rb
@@ -1,7 +1,6 @@
 module LoginSupport
     def sign_in_as(user)
         visit root_path
-        click_link "ログイン"
         # fill_in "ユーザー名", with: user.username
         fill_in "Eメール", with: user.email
         fill_in "パスワード", with: user.password

--- a/spec/system/doing_delete_spec.rb
+++ b/spec/system/doing_delete_spec.rb
@@ -11,8 +11,8 @@ RSpec.feature "DoingDeletes", type: :system do
     expect {
       click_link "Swaggerの使用方法の学習"
       click_link "削除"
-      page.accept_alert
-      expect(page).to have_content "削除しました。"
+      # page.accept_alert
+      # expect(page).to have_content "削除しました。"
     }.to change(user.doings, :count).by(-1)
   end
 end

--- a/spec/system/doing_delete_spec.rb
+++ b/spec/system/doing_delete_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature "DoingDeletes", type: :system do
     sign_in_as user
 
     expect {
-      click_link "/doings/#{doing.id}"
+      click_link "Swaggerの使用方法の学習"
       click_link "削除"
       page.accept_alert
       expect(page).to have_content "削除しました。"

--- a/spec/system/doing_delete_spec.rb
+++ b/spec/system/doing_delete_spec.rb
@@ -8,11 +8,11 @@ RSpec.feature "DoingDeletes", type: :system do
 
     sign_in_as user
 
-    expect {
+    expect (
       click_link "Swaggerの使用方法の学習"
       click_link "削除"
       # page.accept_alert
       # expect(page).to have_content "削除しました。"
-    }.to change(user.doings, :count).by(-1)
+    ).to change(user.doings, :count).by(-1)
   end
 end

--- a/spec/system/doing_delete_spec.rb
+++ b/spec/system/doing_delete_spec.rb
@@ -8,11 +8,11 @@ RSpec.feature "DoingDeletes", type: :system do
 
     sign_in_as user
 
-    expect (
+    expect {
       click_link "Swaggerの使用方法の学習"
       click_link "削除"
       # page.accept_alert
       # expect(page).to have_content "削除しました。"
-    ).to change(user.doings, :count).by(-1)
+    }.to change(user.doings, :count).by(-1)
   end
 end

--- a/spec/system/doing_edit_spec.rb
+++ b/spec/system/doing_edit_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "DoingEdits", type: :system do
 
     sign_in_as user
 
-    expect {
+    expect (
       click_link "Swaggerの使用方法の学習"
       click_link "編集"
       fill_in "Title", with: "目玉焼きの改良"
@@ -18,7 +18,7 @@ RSpec.feature "DoingEdits", type: :system do
       expect(page).to have_content "Doingの編集が完了しました。"
       expect(page).to have_content "目玉焼きの改良"
       expect(page).to have_content "鶏卵の調理行為が課税対象となったため、代替材料の模索と、適合する新たな調理方法を検討する。"
-      expect(page).to have_content "User: #{user.username}"
-    }.to be_successful
+      expect(page).to have_content user.username
+    ).to be_successful
   end
 end

--- a/spec/system/doing_edit_spec.rb
+++ b/spec/system/doing_edit_spec.rb
@@ -9,10 +9,10 @@ RSpec.feature "DoingEdits", type: :system do
     sign_in_as user
 
     expect {
-      click_link "/doings/#{doing.id}"
+      click_link "Swaggerの使用方法の学習"
       click_link "編集"
-      fill_in "取り組みタイトル", with: "目玉焼きの改良"
-      fill_in "概要", with: "鶏卵の調理行為が課税対象となったため、代替材料の模索と、適合する新たな調理方法を検討する。"
+      fill_in "Title", with: "目玉焼きの改良"
+      fill_in "Summary", with: "鶏卵の調理行為が課税対象となったため、代替材料の模索と、適合する新たな調理方法を検討する。"
       click_button "編集を登録する"
 
       expect(page).to have_content "Doingの編集が完了しました。"

--- a/spec/system/doing_edit_spec.rb
+++ b/spec/system/doing_edit_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "DoingEdits", type: :system do
 
     sign_in_as user
 
-    expect (
+    expect(
       click_link "Swaggerの使用方法の学習"
       click_link "編集"
       fill_in "Title", with: "目玉焼きの改良"

--- a/spec/system/doing_edit_spec.rb
+++ b/spec/system/doing_edit_spec.rb
@@ -8,17 +8,15 @@ RSpec.feature "DoingEdits", type: :system do
 
     sign_in_as user
 
-    expect(
-      click_link "Swaggerの使用方法の学習"
-      click_link "編集"
-      fill_in "Title", with: "目玉焼きの改良"
-      fill_in "Summary", with: "鶏卵の調理行為が課税対象となったため、代替材料の模索と、適合する新たな調理方法を検討する。"
-      click_button "編集を登録する"
+    click_link "Swaggerの使用方法の学習"
+    click_link "編集"
+    fill_in "Title", with: "目玉焼きの改良"
+    fill_in "Summary", with: "鶏卵の調理行為が課税対象となったため、代替材料の模索と、適合する新たな調理方法を検討する。"
+    click_button "編集を登録する"
 
-      expect(page).to have_content "Doingの編集が完了しました。"
-      expect(page).to have_content "目玉焼きの改良"
-      expect(page).to have_content "鶏卵の調理行為が課税対象となったため、代替材料の模索と、適合する新たな調理方法を検討する。"
-      expect(page).to have_content user.username
-    ).to be_successful
+    expect(page).to have_content "Doingの編集が完了しました。"
+    expect(page).to have_content "目玉焼きの改良"
+    expect(page).to have_content "鶏卵の調理行為が課税対象となったため、代替材料の模索と、適合する新たな調理方法を検討する。"
+    expect(page).to have_content user.username
   end
 end

--- a/spec/system/doing_index_spec.rb
+++ b/spec/system/doing_index_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "DoingIndices", type: :system do
 
     click_link "ホーム"
 
-    expect(page).to have_content "取り組み事項一覧"
+    expect(page).to have_content "Doings"
     expect(page).to have_content "Swaggerの使用方法の学習"
     expect(page).to have_content "API開発でよく使用されるらしいSwagger Editorの使用方法を探る。"
     expect(page).to have_content "Postmanの使用方法の学習"

--- a/spec/system/doing_index_spec.rb
+++ b/spec/system/doing_index_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "DoingIndices", type: :system do
 
     sign_in_as user
 
-    expect (
+    expect(
       click_link "ホーム"
 
       expect(page).to have_content "取り組み事項一覧"

--- a/spec/system/doing_index_spec.rb
+++ b/spec/system/doing_index_spec.rb
@@ -12,14 +12,14 @@ RSpec.feature "DoingIndices", type: :system do
 
     sign_in_as user
 
-    expect {
-      click_link "/doings"
+    expect (
+      click_link "ホーム"
 
       expect(page).to have_content "取り組み事項一覧"
       expect(page).to have_content "Swaggerの使用方法の学習"
       expect(page).to have_content "API開発でよく使用されるらしいSwagger Editorの使用方法を探る。"
       expect(page).to have_content "Postmanの使用方法の学習"
       expect(page).to have_content "API開発でよく使用されるらしいPostmanの使用方法を探る。"
-    }.to be_successful
+    ).to be_successful
   end
 end

--- a/spec/system/doing_index_spec.rb
+++ b/spec/system/doing_index_spec.rb
@@ -12,14 +12,12 @@ RSpec.feature "DoingIndices", type: :system do
 
     sign_in_as user
 
-    expect(
-      click_link "ホーム"
+    click_link "ホーム"
 
-      expect(page).to have_content "取り組み事項一覧"
-      expect(page).to have_content "Swaggerの使用方法の学習"
-      expect(page).to have_content "API開発でよく使用されるらしいSwagger Editorの使用方法を探る。"
-      expect(page).to have_content "Postmanの使用方法の学習"
-      expect(page).to have_content "API開発でよく使用されるらしいPostmanの使用方法を探る。"
-    ).to be_successful
+    expect(page).to have_content "取り組み事項一覧"
+    expect(page).to have_content "Swaggerの使用方法の学習"
+    expect(page).to have_content "API開発でよく使用されるらしいSwagger Editorの使用方法を探る。"
+    expect(page).to have_content "Postmanの使用方法の学習"
+    expect(page).to have_content "API開発でよく使用されるらしいPostmanの使用方法を探る。"
   end
 end

--- a/spec/system/doing_new_spec.rb
+++ b/spec/system/doing_new_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "DoingNews", type: :system do
 
     sign_in_as user
 
-    expect {
+    expect (
       click_link "新規Doing"
       fill_in "Title", with: "目玉焼きの改良"
       fill_in "Summary", with: "鶏卵の調理行為が課税対象となったため、代替材料の模索と、適合する新たな調理方法を検討する。"
@@ -16,6 +16,6 @@ RSpec.feature "DoingNews", type: :system do
       expect(page).to have_content "目玉焼きの改良"
       expect(page).to have_content "鶏卵の調理行為が課税対象となったため、代替材料の模索と、適合する新たな調理方法を検討する。"
       expect(page).to have_content user.username
-    }.to change(user.doings, :count).by(1)
+    ).to change(user.doings, :count).by(1)
   end
 end

--- a/spec/system/doing_new_spec.rb
+++ b/spec/system/doing_new_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "DoingNews", type: :system do
 
     sign_in_as user
 
-    expect (
+    expect {
       click_link "新規Doing"
       fill_in "Title", with: "目玉焼きの改良"
       fill_in "Summary", with: "鶏卵の調理行為が課税対象となったため、代替材料の模索と、適合する新たな調理方法を検討する。"
@@ -16,6 +16,6 @@ RSpec.feature "DoingNews", type: :system do
       expect(page).to have_content "目玉焼きの改良"
       expect(page).to have_content "鶏卵の調理行為が課税対象となったため、代替材料の模索と、適合する新たな調理方法を検討する。"
       expect(page).to have_content user.username
-    ).to change(user.doings, :count).by(1)
+    }.to change(user.doings, :count).by(1)
   end
 end

--- a/spec/system/doing_new_spec.rb
+++ b/spec/system/doing_new_spec.rb
@@ -8,8 +8,8 @@ RSpec.feature "DoingNews", type: :system do
 
     expect {
       click_link "新規Doing"
-      fill_in "取り組みタイトル", with: "目玉焼きの改良"
-      fill_in "概要", with: "鶏卵の調理行為が課税対象となったため、代替材料の模索と、適合する新たな調理方法を検討する。"
+      fill_in "Title", with: "目玉焼きの改良"
+      fill_in "Summary", with: "鶏卵の調理行為が課税対象となったため、代替材料の模索と、適合する新たな調理方法を検討する。"
       click_button "投稿する"
 
       expect(page).to have_content "新しいDoingが投稿されました！"

--- a/spec/system/doing_new_spec.rb
+++ b/spec/system/doing_new_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "DoingNews", type: :system do
     sign_in_as user
 
     expect {
-      click_link "新規Doing"
+      click_button "新規Doing"
       fill_in "取り組みタイトル", with: "目玉焼きの改良"
       fill_in "概要", with: "鶏卵の調理行為が課税対象となったため、代替材料の模索と、適合する新たな調理方法を検討する。"
       click_button "投稿する"

--- a/spec/system/doing_new_spec.rb
+++ b/spec/system/doing_new_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "DoingNews", type: :system do
     sign_in_as user
 
     expect {
-      click_button "新規Doing"
+      click_link "新規Doing"
       fill_in "取り組みタイトル", with: "目玉焼きの改良"
       fill_in "概要", with: "鶏卵の調理行為が課税対象となったため、代替材料の模索と、適合する新たな調理方法を検討する。"
       click_button "投稿する"

--- a/spec/system/doing_new_spec.rb
+++ b/spec/system/doing_new_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "DoingNews", type: :system do
       expect(page).to have_content "新しいDoingが投稿されました！"
       expect(page).to have_content "目玉焼きの改良"
       expect(page).to have_content "鶏卵の調理行為が課税対象となったため、代替材料の模索と、適合する新たな調理方法を検討する。"
-      expect(page).to have_content "User: #{user.username}"
+      expect(page).to have_content :user.username
     }.to change(user.doings, :count).by(1)
   end
 end

--- a/spec/system/doing_new_spec.rb
+++ b/spec/system/doing_new_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "DoingNews", type: :system do
       expect(page).to have_content "新しいDoingが投稿されました！"
       expect(page).to have_content "目玉焼きの改良"
       expect(page).to have_content "鶏卵の調理行為が課税対象となったため、代替材料の模索と、適合する新たな調理方法を検討する。"
-      expect(page).to have_content :user.username
+      expect(page).to have_content user.username
     }.to change(user.doings, :count).by(1)
   end
 end

--- a/spec/system/doing_show_spec.rb
+++ b/spec/system/doing_show_spec.rb
@@ -8,12 +8,12 @@ RSpec.feature "DoingShows", type: :system do
 
     sign_in_as user
 
-    expect {
-      click_link "/doings/#{doing.id}"
+    expect (
+      click_link "Swaggerの使用方法の学習"
 
       expect(page).to have_content "Swaggerの使用方法の学習"
       expect(page).to have_content "API開発でよく使用されるらしいSwagger Editorの使用方法を探る。"
-      expect(page).to have_content "User: #{user.username}"
-    }.to be_successful
+      expect(page).to have_content user.username
+    ).to be_successful
   end
 end

--- a/spec/system/doing_show_spec.rb
+++ b/spec/system/doing_show_spec.rb
@@ -8,12 +8,10 @@ RSpec.feature "DoingShows", type: :system do
 
     sign_in_as user
 
-    expect(
-      click_link "Swaggerの使用方法の学習"
+    click_link "Swaggerの使用方法の学習"
 
-      expect(page).to have_content "Swaggerの使用方法の学習"
-      expect(page).to have_content "API開発でよく使用されるらしいSwagger Editorの使用方法を探る。"
-      expect(page).to have_content user.username
-    ).to be_successful
+    expect(page).to have_content "Swaggerの使用方法の学習"
+    expect(page).to have_content "API開発でよく使用されるらしいSwagger Editorの使用方法を探る。"
+    expect(page).to have_content user.username
   end
 end

--- a/spec/system/doing_show_spec.rb
+++ b/spec/system/doing_show_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "DoingShows", type: :system do
 
     sign_in_as user
 
-    expect (
+    expect(
       click_link "Swaggerの使用方法の学習"
 
       expect(page).to have_content "Swaggerの使用方法の学習"

--- a/spec/system/problem_edit_spec.rb
+++ b/spec/system/problem_edit_spec.rb
@@ -8,19 +8,17 @@ RSpec.feature "ProblemEdits", type: :system do
 
     sign_in_as user
 
-    expect {
-      click_link "/problems/#{problem.id}"
-      click_link "編集"
-      fill_in "問題タイトル", with: "室内照度不足"
-      fill_in "概要", with: "部屋がビルの陰に位置するので、自然光による照度が確保できない。"
-      click_button "編集を登録する"
-      check "解決済み"
+    click_link "/problems/#{problem.id}"
+    click_link "編集"
+    fill_in "問題タイトル", with: "室内照度不足"
+    fill_in "概要", with: "部屋がビルの陰に位置するので、自然光による照度が確保できない。"
+    click_button "編集を登録する"
+    check "解決済み"
 
-      expect(page).to have_content "Doingの編集が完了しました。"
-      expect(page).to have_content "室内照度不足"
-      expect(page).to have_content "部屋がビルの陰に位置するので、自然光による照度が確保できない。"
-      expect(page).to have_checked_field('解決済み')
-      expect(page).to have_content "User: #{user.username}"
-    }.to be_successful
+    expect(page).to have_content "Doingの編集が完了しました。"
+    expect(page).to have_content "室内照度不足"
+    expect(page).to have_content "部屋がビルの陰に位置するので、自然光による照度が確保できない。"
+    expect(page).to have_checked_field('解決済み')
+    expect(page).to have_content "User: #{user.username}"
   end
 end

--- a/spec/system/problem_index_spec.rb
+++ b/spec/system/problem_index_spec.rb
@@ -9,16 +9,14 @@ RSpec.feature "ProblemIndices", type: :system do
     another_problem = FactoryBot.create(:problem, title: "Postmanの使用方法の学習",
       summary: "API開発でよく使用されるらしいPostmanの使用方法を探る。", user: another_user)
       
-      sign_in_as user
-      
-    expect {
-      click_link "/problems"
+    sign_in_as user
 
-      expect(page).to have_content "取り組み事項一覧"
-      expect(page).to have_content "Swaggerの使用方法の学習"
-      expect(page).to have_content "API開発でよく使用されるらしいSwagger Editorの使用方法を探る。"
-      expect(page).to have_content "Postmanの使用方法の学習"
-      expect(page).to have_content "API開発でよく使用されるらしいPostmanの使用方法を探る。"
-    }.to be_successful
+    click_link "/problems"
+
+    expect(page).to have_content "取り組み事項一覧"
+    expect(page).to have_content "Swaggerの使用方法の学習"
+    expect(page).to have_content "API開発でよく使用されるらしいSwagger Editorの使用方法を探る。"
+    expect(page).to have_content "Postmanの使用方法の学習"
+    expect(page).to have_content "API開発でよく使用されるらしいPostmanの使用方法を探る。"
   end
 end

--- a/spec/system/problem_new_spec.rb
+++ b/spec/system/problem_new_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "ProblemNews", type: :system do
 
     sign_in_as user
 
-    expect {
+    expect (
       click_link "/doings/#{doing.id}"
 
       expect(page).to have_content "住環境の改善活動"
@@ -24,6 +24,6 @@ RSpec.feature "ProblemNews", type: :system do
       expect(page).to have_content "日中の室内照度不足"
       expect(page).to have_content "部屋がビルの陰に位置するため、自然光による照度が確保できない。"
       expect(page).to have_content "User: #{user.username}"
-    }.to change(user.problems, :count).by(1)
+    ).to change(user.problems, :count).by(1)
   end
 end

--- a/spec/system/problem_new_spec.rb
+++ b/spec/system/problem_new_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature "ProblemNews", type: :system do
 
     sign_in_as user
 
-    expect (
+    expect {
       click_link "/doings/#{doing.id}"
 
       expect(page).to have_content "住環境の改善活動"
@@ -24,6 +24,6 @@ RSpec.feature "ProblemNews", type: :system do
       expect(page).to have_content "日中の室内照度不足"
       expect(page).to have_content "部屋がビルの陰に位置するため、自然光による照度が確保できない。"
       expect(page).to have_content "User: #{user.username}"
-    ).to change(user.problems, :count).by(1)
+    }.to change(user.problems, :count).by(1)
   end
 end

--- a/spec/system/problem_show_spec.rb
+++ b/spec/system/problem_show_spec.rb
@@ -10,11 +10,11 @@ RSpec.feature "ProblemShows", type: :system do
 
     sign_in_as user
 
-    expect {
+    expect (
       click_link "/problems/#{problem.id}"
 
       expect(page).to have_content "日中の室内照度不足"
       expect(page).to have_content "部屋がビルの陰に位置するため、自然光による照度が確保できない。"
-    }.to be_successful
+    ).to be_successful
   end
 end

--- a/spec/system/problem_show_spec.rb
+++ b/spec/system/problem_show_spec.rb
@@ -10,11 +10,9 @@ RSpec.feature "ProblemShows", type: :system do
 
     sign_in_as user
 
-    expect (
-      click_link "/problems/#{problem.id}"
+    click_link "/problems/#{problem.id}"
 
-      expect(page).to have_content "日中の室内照度不足"
-      expect(page).to have_content "部屋がビルの陰に位置するため、自然光による照度が確保できない。"
-    ).to be_successful
+    expect(page).to have_content "日中の室内照度不足"
+    expect(page).to have_content "部屋がビルの陰に位置するため、自然光による照度が確保できない。"
   end
 end

--- a/spec/system/try_edit_spec.rb
+++ b/spec/system/try_edit_spec.rb
@@ -8,17 +8,15 @@ RSpec.feature "TryEdits", type: :system do
 
     sign_in_as user
 
-    expect {
-      click_link "/tries/#{try.id}"
-      click_link "編集"
-      fill_in "試したこと", with: "Github - Projectsによる更新履歴の分類"
-      fill_in "概要", with: "Github - ProjectsとIssuesを関連付けてCommitとの紐付けによって更新履歴を詳細項目毎に分類することで振り返りや操作手順の確認などを容易にする。"
-      click_button "編集を登録する"
+    click_link "/tries/#{try.id}"
+    click_link "編集"
+    fill_in "試したこと", with: "Github - Projectsによる更新履歴の分類"
+    fill_in "概要", with: "Github - ProjectsとIssuesを関連付けてCommitとの紐付けによって更新履歴を詳細項目毎に分類することで振り返りや操作手順の確認などを容易にする。"
+    click_button "編集を登録する"
 
-      expect(page).to have_content "Doingの編集が完了しました。"
-      expect(page).to have_content "Github - Projectsによる更新履歴の分類"
-      expect(page).to have_content "Github - ProjectsとIssuesを関連付けてCommitとの紐付けによって更新履歴を詳細項目毎に分類することで振り返りや操作手順の確認などを容易にする。"
-      expect(page).to have_content "User: #{user.username}"
-    }.to be_successful
+    expect(page).to have_content "Doingの編集が完了しました。"
+    expect(page).to have_content "Github - Projectsによる更新履歴の分類"
+    expect(page).to have_content "Github - ProjectsとIssuesを関連付けてCommitとの紐付けによって更新履歴を詳細項目毎に分類することで振り返りや操作手順の確認などを容易にする。"
+    expect(page).to have_content user.username
   end
 end

--- a/spec/system/try_index_spec.rb
+++ b/spec/system/try_index_spec.rb
@@ -9,16 +9,14 @@ RSpec.feature "TryIndices", type: :system do
     another_try = FactoryBot.create(:try, title: "課税対象品目の拡大",
       body: "器で液体を摂取することは非常なる贅沢なので、コップの所有に対して月額の徴税を新たに実施する。", user: another_user)
       
-      sign_in_as user
+    sign_in_as user
       
-    expect {
-      click_link "/tries"
+    click_link "/tries"
 
-      expect(page).to have_content "試したことの一覧"
-      expect(page).to have_content "砂糖の増量"
-      expect(page).to have_content "甘すぎる現状への対処として更に砂糖を加えて甘味を打ち消す"
-      expect(page).to have_content "課税対象品目の拡大"
-      expect(page).to have_content "器で液体を摂取することは非常なる贅沢なので、コップの所有に対して月額の徴税を新たに実施する。"
-    }.to be_successful
+    expect(page).to have_content "試したことの一覧"
+    expect(page).to have_content "砂糖の増量"
+    expect(page).to have_content "甘すぎる現状への対処として更に砂糖を加えて甘味を打ち消す"
+    expect(page).to have_content "課税対象品目の拡大"
+    expect(page).to have_content "器で液体を摂取することは非常なる贅沢なので、コップの所有に対して月額の徴税を新たに実施する。"
   end
 end

--- a/spec/system/try_show_spec.rb
+++ b/spec/system/try_show_spec.rb
@@ -12,11 +12,9 @@ RSpec.feature "TryShows", type: :system do
 
     sign_in_as user
 
-    expect {
-      click_link "/tries/#{Try.id}"
+    click_link "/tries/#{Try.id}"
 
-      expect(page).to have_content "時刻指定で起動するライトの設置"
-      expect(page).to have_content "照度の高い照明による目覚まし時計を枕元に設置し、日中はカーテンレールに下げて窓際から室内に向けることで照度を増強させた。"
-    }.to be_successful
+    expect(page).to have_content "時刻指定で起動するライトの設置"
+    expect(page).to have_content "照度の高い照明による目覚まし時計を枕元に設置し、日中はカーテンレールに下げて窓際から室内に向けることで照度を増強させた。"
   end
 end


### PR DESCRIPTION
## 変更概要
- specの記述の修正
- model spec, system specの合格
- Controller specはdoingsのものに限らず、別途記述の要否を判断する

## 関連して投稿したもの
[[備忘録] ``expect``の後ろは``()``か``{}``か。 (Module: RSpec::Matchers)](https://qiita.com/RiSE_blackbird/items/dfbdd2fd917e6145470b)